### PR TITLE
fix streamlit_ui host and port

### DIFF
--- a/besser/bot/platforms/websocket/streamlit_ui.py
+++ b/besser/bot/platforms/websocket/streamlit_ui.py
@@ -103,7 +103,15 @@ def main():
         st.session_state['queue'] = queue.Queue()
 
     if 'websocket' not in st.session_state:
-        ws = websocket.WebSocketApp("ws://localhost:8765/",
+        try:
+            # We get the websocket host and port from the script arguments
+            host = sys.argv[1]
+            port = sys.argv[2]
+        except Exception as e:
+            # If they are not provided, we use default values
+            host = 'localhost'
+            port = '8765'
+        ws = websocket.WebSocketApp(f"ws://{host}:{port}/",
                                     on_open=on_open,
                                     on_message=on_message,
                                     on_error=on_error,

--- a/besser/bot/platforms/websocket/websocket_platform.py
+++ b/besser/bot/platforms/websocket/websocket_platform.py
@@ -107,9 +107,14 @@ class WebSocketPlatform(Platform):
         if self._use_ui:
             def run_streamlit() -> None:
                 """Run the Streamlit UI in a dedicated thread."""
-                subprocess.run(["streamlit", "run", os.path.abspath(inspect.getfile(streamlit_ui)),
-                                "--server.address", self._bot.get_property(websocket.STREAMLIT_HOST),
-                                "--server.port", str(self._bot.get_property(websocket.STREAMLIT_PORT))])
+                subprocess.run([
+                    "streamlit", "run",
+                    "--server.address", self._bot.get_property(websocket.STREAMLIT_HOST),
+                    "--server.port", str(self._bot.get_property(websocket.STREAMLIT_PORT)),
+                    os.path.abspath(inspect.getfile(streamlit_ui)),
+                    self._bot.get_property(websocket.WEBSOCKET_HOST),
+                    str(self._bot.get_property(websocket.WEBSOCKET_PORT))
+                ])
 
             thread = threading.Thread(target=run_streamlit)
             logging.info(f'Running Streamlit UI in another thread')


### PR DESCRIPTION
The websocket host and port set in the bot configuration was not being used by the streamlit ui. Now, they are passed as arguments with the streamlit command and retrieved in the ui to create the right connection