### PR TITLE
Added label to Software Heritage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![PyPI - License](https://img.shields.io/pypi/l/besser-agentic-framework)](https://opensource.org/license/MIT)
 [![LinkedIn](https://img.shields.io/badge/-LinkedIn-blue?logo=Linkedin&logoColor=white&link=https://www.linkedin.com/in/pireseduardo/)](https://www.linkedin.com/company/besser-agentic-framework)
 [![GitHub Repo stars](https://img.shields.io/github/stars/besser-pearl/besser-agentic-framework?style=social)](https://star-history.com/#besser-pearl/besser-agentic-framework)
+[![SWH](https://archive.softwareheritage.org/badge/origin/https://github.com/BESSER-PEARL/BESSER-Agentic-Framework/)](https://archive.softwareheritage.org/browse/origin/?origin_url=https://github.com/BESSER-PEARL/BESSER-Agentic-Framework)
 
 The BESSER Agentic Framework (BAF) is part of the [BESSER](https://modeling-languages.com/a-smart-low-code-platform-for-smart-software-in-luxembourg-goodbye-barcelona/) (Building Better Smart Software Faster) project. It aims
 to make the design and implementation of agents, bots and chatbots easier and accessible for everyone.


### PR DESCRIPTION
A backup of this repository is created in the Software Heritage archive, and its corresponding link is added to the README file.