### PR TITLE
Allows users to set session variables from the UI.

### DIFF
--- a/besser/agent/platforms/payload.py
+++ b/besser/agent/platforms/payload.py
@@ -15,6 +15,11 @@ class PayloadAction(Enum):
     USER_FILE = 'user_file'
     """PayloadAction: Indicates that the payload's purpose is to send a user file."""
 
+    USER_SET_VARIABLE = 'user_set_variable'
+    """PayloadAction: Indicates that the user intends to set a session variable. The payload must include a dictionary containing the variable name and its value, 
+sent as a Payload message.
+    """
+
     RESET = 'reset'
     """PayloadAction: Use the :class:`~besser.agent.platforms.websocket.websocket_platform.WebSocketPlatform` on this
     agent.

--- a/besser/agent/platforms/websocket/websocket_platform.py
+++ b/besser/agent/platforms/websocket/websocket_platform.py
@@ -125,6 +125,11 @@ class WebSocketPlatform(Platform):
                         self._agent.receive_event(event)
                     elif payload.action == PayloadAction.RESET.value:
                         self._agent.reset(session.id)
+                    elif payload.action == PayloadAction.USER_SET_VARIABLE.value:
+                        key = next(iter(payload.message))
+                        value = payload.message[key]
+                        session.set(key, value)
+                        logger.info(f"Session variable {key} set to {value}.")
             except ConnectionClosedError:
                 pass
                 # logger.error(f'The client closed unexpectedly')


### PR DESCRIPTION
### Allows users to set session variables from the UI.

In the UI, the user only needs to send a Payload of type USER_SET_VARIABLE containing the desired session variable and its value formatted as a dict.

This session variable can latter be used by the agent as desired. 

Example: 
```
payload = Payload(action=PayloadAction.USER_SET_VARIABLE, message={'variable_test':False})
ws = st.session_state[WEBSOCKET]
ws.send(json.dumps(payload, cls=PayloadEncoder))
```