### PR TITLE
Allows users to set session variables from the UI - updated.

### DIFF
--- a/besser/agent/platforms/payload.py
+++ b/besser/agent/platforms/payload.py
@@ -16,8 +16,7 @@ class PayloadAction(Enum):
     """PayloadAction: Indicates that the payload's purpose is to send a user file."""
 
     USER_SET_VARIABLE = 'user_set_variable'
-    """PayloadAction: Indicates that the user intends to set a session variable. The payload must include a dictionary containing the variable name and its value, 
-sent as a Payload message.
+    """PayloadAction: Indicates that the user intends to set a session variable. The payload must include a dictionary containing the variable name and its value, sent as a Payload message.
     """
 
     RESET = 'reset'

--- a/besser/agent/platforms/websocket/websocket_platform.py
+++ b/besser/agent/platforms/websocket/websocket_platform.py
@@ -126,10 +126,12 @@ class WebSocketPlatform(Platform):
                     elif payload.action == PayloadAction.RESET.value:
                         self._agent.reset(session.id)
                     elif payload.action == PayloadAction.USER_SET_VARIABLE.value:
-                        key = next(iter(payload.message))
-                        value = payload.message[key]
-                        session.set(key, value)
-                        logger.info(f"Session variable {key} set to {value}.")
+                        if not isinstance(payload.message, dict) or not payload.message:
+                            logger.error('Invalid message format for USER_SET_VARIABLE')
+                            continue  # skip this iteration
+                        for key, value in payload.message.items():
+                            session.set(key, value)
+                            logger.info(f"Session variable {key} set to {value}.")
             except ConnectionClosedError:
                 pass
                 # logger.error(f'The client closed unexpectedly')


### PR DESCRIPTION
### Updates PR #143 . 
 - Applies suggestions from copilot 
 - pull into dev
 - change branch name to comply with the standard

### Allows users to set session variables from the UI.

In the UI, the user only needs to send a Payload of type USER_SET_VARIABLE containing the desired session variables and its values formatted as a dict.

This session variable can latter be used by the agent as desired.

Example:
```
payload = Payload(action=PayloadAction.USER_SET_VARIABLE, message={'variable_test':False})
ws = st.session_state[WEBSOCKET]
ws.send(json.dumps(payload, cls=PayloadEncoder))
```` 