### PR TITLE
feat: add origins support to WebSocketPlatform

### DIFF
--- a/baf/core/agent.py
+++ b/baf/core/agent.py
@@ -146,6 +146,8 @@ class Agent:
             return
 
         if isinstance(data, list):
+            if prefix:
+                self._config[prefix] = data
             for index, item in enumerate(data):
                 if isinstance(item, dict) and len(item) == 1:
                     item_key, item_value = next(iter(item.items()))

--- a/baf/platforms/websocket/__init__.py
+++ b/baf/platforms/websocket/__init__.py
@@ -33,6 +33,26 @@ type: ``int``
 default value: ``None``
 """
 
+WEBSOCKET_ORIGINS = Property('platforms.websocket.origins', list, None)
+"""
+List of allowed origins for WebSocket connections. When set, only connections from these origins
+will be accepted. When :obj:`None` (default), connections from any origin are allowed.
+
+Example in ``config.yaml``::
+
+    platforms:
+      websocket:
+        origins:
+          - "https://editor.besser-pearl.org"
+          - "https://localhost"
+
+name: ``platforms.websocket.origins``
+
+type: ``list``
+
+default value: ``None``
+"""
+
 STREAMLIT_HOST = Property('platforms.websocket.streamlit.host', str, 'localhost')
 """
 The Streamlit UI host address. If you are using our default UI, you must define its address where you can access and 

--- a/baf/platforms/websocket/websocket_platform.py
+++ b/baf/platforms/websocket/websocket_platform.py
@@ -227,11 +227,13 @@ class WebSocketPlatform(Platform):
     def initialize(self) -> None:
         self._host = self._agent.get_property(websocket.WEBSOCKET_HOST)
         self._port = self._agent.get_property(websocket.WEBSOCKET_PORT)
+        origins = self._agent.get_property(websocket.WEBSOCKET_ORIGINS)
         self._websocket_server = serve(
             handler=self._message_handler,
             host=self._host,
             port=self._port,
-            max_size=self._agent.get_property(websocket.WEBSOCKET_MAX_SIZE)
+            max_size=self._agent.get_property(websocket.WEBSOCKET_MAX_SIZE),
+            origins=origins,
         )
 
     def start(self) -> None:

--- a/baf/test/examples/config.yaml
+++ b/baf/test/examples/config.yaml
@@ -18,6 +18,9 @@ platforms:
   websocket:
     host: localhost
     port: 8765
+    # origins:
+    #   - "https://example.com"
+    #   - "https://app.example.com"
     streamlit:
       host: localhost
       port: 5000

--- a/docs/source/wiki/platforms/websocket_platform.rst
+++ b/docs/source/wiki/platforms/websocket_platform.rst
@@ -33,6 +33,25 @@ Of course, you are free to use or create your own UI as long as it has a WebSock
     There are some properties the agent needs in order to properly set the WebSocket connection. More details in the
     :any:`configuration properties <properties-websocket_platform>` documentation.
 
+Restricting allowed origins
+---------------------------
+
+By default, the WebSocket server accepts connections from any origin. You can restrict which origins are
+allowed to connect by setting the ``origins`` property in your ``config.yaml``:
+
+.. code:: yaml
+
+    platforms:
+      websocket:
+        host: localhost
+        port: 8765
+        origins:
+          - "https://editor.besser-pearl.org"
+          - "https://experimental.besser-pearl.org"
+
+When ``origins`` is set, the server will reject WebSocket upgrade requests from any origin not in the list.
+When not set (default), all origins are accepted.
+
 How to use it
 -------------
 


### PR DESCRIPTION
## Summary

- **Added `WEBSOCKET_ORIGINS` property** to restrict which domains can establish WebSocket connections
- **Updated core property system** to support `list` type properties from YAML config
- **Fully backwards compatible** — defaults to `None` (accept all origins, same as current behavior)

Closes #171

## Changes

| File | Change |
|------|--------|
| `baf/core/agent.py` | Store raw YAML lists in config so `list` properties work |
| `baf/platforms/websocket/__init__.py` | Added `WEBSOCKET_ORIGINS` property with docstring |
| `baf/platforms/websocket/websocket_platform.py` | Pass `origins` to `websockets.serve()` |
| `baf/test/examples/config.yaml` | Added commented-out `origins` example |
| `docs/source/wiki/platforms/websocket_platform.rst` | Added "Restricting allowed origins" docs section |

## Usage

```yaml
platforms:
  websocket:
    host: localhost
    port: 8765
    origins:
      - "https://editor.besser-pearl.org"
      - "https://localhost"
```

## Test plan

- [x] Verify WebSocket server starts normally without `origins` config (backwards compat)
- [x] Verify connections from allowed origins succeed when `origins` is set
- [x] Verify connections from disallowed origins are rejected
- [x] Verify existing properties (host, port, max_size) still work correctly
