### PR TITLE
fix: wait for platform to be ready before starting agent session

### DIFF
--- a/baf/core/session.py
+++ b/baf/core/session.py
@@ -133,6 +133,17 @@ class Session:
 
         def start_event_loop():
             logger.debug(f'Starting Event Loop for session: {self.id}')
+            # Wait for the platform to finish starting before running the agent.
+            # Platforms run in their own threads and may not be ready immediately.
+            timeout = 30  # seconds
+            elapsed = 0.0
+            interval = 0.05  # 50ms polling interval
+            while not self._platform.running:
+                if elapsed >= timeout:
+                    logger.error(f'Platform did not start within {timeout}s for session {self.id}. Aborting session start.')
+                    return
+                time.sleep(interval)
+                elapsed += interval
             asyncio.set_event_loop(self._event_loop)
             asyncio.get_event_loop().call_soon(self.manage_transition)
             self._event_loop.run_forever()


### PR DESCRIPTION
Fixes #98

## Problem

When opening a new session, the agent starts immediately while the 
platform is still initializing in its own thread. This creates a race 
condition where the agent can begin processing before the platform is 
ready to handle messages.

This issue was already partially handled — each platform correctly sets 
`self.running = True` after startup (e.g. websocket_platform.py:175, 
:320). However, the session never checked this flag before starting.

## Fix

Added a polling wait in `_run_event_thread` that checks 
`platform.running` before starting the event loop. The wait polls every 
50ms and times out after 30 seconds, logging an error and aborting 
gracefully if the platform fails to start in time.

## Files changed

- `baf/core/session.py` — added platform readiness check in 
`_run_event_thread`

## Testing

No existing unit test infrastructure in the repo. Fix was verified by 
code inspection — the `running` flag is already correctly managed by 
each platform implementation. The session-side check was the missing 
piece.