### PR TITLE
deps: bump nltk to 3.10.3 to clear reported advisories

### DIFF
--- a/requirements/requirements-core.txt
+++ b/requirements/requirements-core.txt
@@ -4,7 +4,7 @@ gidgetlab==2.1.0
 dateparser==1.1.8
 langdetect==1.0.9
 markdownify==1.2.2
-nltk==3.9.1
+nltk==3.10.3
 numpy==1.26.4; python_version < "3.13"
 numpy>=2.1,<3; python_version >= "3.13"
 pandas==2.3.3


### PR DESCRIPTION
Updates nltk to address the advisories reported against 3.9.1.

Evidence:
- requirements/requirements-core.txt pinned nltk==3.9.1
- osv-scanner reported 29 advisories for nltk@3.9.1, including GHSA-m42h-3232-vpv3 (path traversal in nltk.data.load), GHSA-848c-c2cx-j7qx (eval injection in collocations CLI), PYSEC-2026-597, PYSEC-2026-3657 and PYSEC-2026-3581 through PYSEC-2026-3584
- updated version: 3.10.3

Validation:
- osv-scanner no longer reports any advisory for nltk@3.10.3
- python -m pytest baf/test/components baf/test/dependencies -q (the command from .github/workflows/install-check.yml) passes: 152 passed, 24 skipped, with the torch extra installed as the workflow does

Note: osv-scanner still reports separate advisories for other pinned dependencies (aiohttp, numpy, requests, sqlalchemy, streamlit). This patch only touches nltk.

Scope: requirements/requirements-core.txt only.
